### PR TITLE
Correct ip_network iterator

### DIFF
--- a/ipaddress.py
+++ b/ipaddress.py
@@ -646,14 +646,18 @@ class _BaseNetwork(_IPAddressBase):
         """
         network = int(self.network_address)
         broadcast = int(self.broadcast_address)
-        for x in range(network + 1, broadcast):
-            yield self._address_class(x)
+        i = network + 1
+        while i < broadcast:
+            yield self._address_class(i)
+            i += 1
 
     def __iter__(self):
         network = int(self.network_address)
         broadcast = int(self.broadcast_address)
-        for x in range(network, broadcast + 1):
-            yield self._address_class(x)
+        i = network + 1
+        while i < broadcast:
+            yield self._address_class(i)
+            i += 1
 
     def __getitem__(self, n):
         network = int(self.network_address)


### PR DESCRIPTION
The original iterator uses the range function. Iterating large lists
using range can lead to an overflow error.

> > > import ipaddress
> > > for i in ipaddress.ip_network(unicode('2a00:70a0::/32')):
> > > ...   pass
> > > ...
> > > Traceback (most recent call last):
> > >   File "<stdin>", line 1, in <module>
> > >   File "/usr/local/lib/python2.7/dist-packages/ipaddress.py", line 655, in **iter**
> > >     for x in range(network, broadcast + 1):
> > > OverflowError: range() result has too many items
