### PR TITLE
When comparing subnets of different versions, missing % causes the wrong exception to be raised

### DIFF
--- a/ipaddress.py
+++ b/ipaddress.py
@@ -1103,7 +1103,7 @@ class _BaseNetwork(_IPAddressBase):
         try:
             # Always false if one is v4 and the other is v6.
             if a._version != b._version:
-                raise TypeError("%s and %s are not of the same version" (a, b))
+                raise TypeError("%s and %s are not of the same version" % (a, b))
             return (b.network_address <= a.network_address and
                     b.broadcast_address >= a.broadcast_address)
         except AttributeError:

--- a/ipaddress.py
+++ b/ipaddress.py
@@ -1103,7 +1103,8 @@ class _BaseNetwork(_IPAddressBase):
         try:
             # Always false if one is v4 and the other is v6.
             if a._version != b._version:
-                raise TypeError("%s and %s are not of the same version" % (a, b))
+                raise TypeError("%s and %s are not of the same "
+                                "version" % (a, b))
             return (b.network_address <= a.network_address and
                     b.broadcast_address >= a.broadcast_address)
         except AttributeError:


### PR DESCRIPTION
How to reproduce:
```
import ipaddress
ipaddress.ip_network(u"::0/64").subnet_of(ipaddress.ip_network(u"10.0.0.0/8"))
```
This throws:
```
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File ".../.venv/local/lib/python2.7/site-packages/ipaddress.py", line 1115, in subnet_of
    return self._is_subnet_of(self, other)
  File ".../.venv/local/lib/python2.7/site-packages/ipaddress.py", line 1106, in _is_subnet_of
    raise TypeError("%s and %s are not of the same version" (a, b))
TypeError: 'unicode' object is not callable
```

instead of:
```
TypeError: ::/64 and 10.0.0.0/8 are not of the same version
```
