### PR TITLE
Correcting IPv4 Private Networks

### DIFF
--- a/ipaddress.py
+++ b/ipaddress.py
@@ -1686,11 +1686,11 @@ class _IPv4Constants(object):
     _private_networks = [
         IPv4Network('0.0.0.0/8'),
         IPv4Network('10.0.0.0/8'),
+        IPv4Network('100.64.0.0/10'),
         IPv4Network('127.0.0.0/8'),
         IPv4Network('169.254.0.0/16'),
         IPv4Network('172.16.0.0/12'),
-        IPv4Network('192.0.0.0/29'),
-        IPv4Network('192.0.0.170/31'),
+        IPv4Network('192.0.0.0/24'),
         IPv4Network('192.0.2.0/24'),
         IPv4Network('192.168.0.0/16'),
         IPv4Network('198.18.0.0/15'),


### PR DESCRIPTION
Made the changes with the most impact.  

100.64.0.0/10 is Carrier Grade NAT, so it is a private network for an ISP.

[Wikipedia REF](https://en.wikipedia.org/wiki/IPv4#Special-use_addresses)