### PR TITLE
Add missing % in string formatting

### DIFF
--- a/ipaddress.py
+++ b/ipaddress.py
@@ -1103,7 +1103,7 @@ class _BaseNetwork(_IPAddressBase):
         try:
             # Always false if one is v4 and the other is v6.
             if a._version != b._version:
-                raise TypeError("%s and %s are not of the same version" (a, b))
+                raise TypeError("%s and %s are not of the same version" % (a, b))
             return (b.network_address <= a.network_address and
                     b.broadcast_address >= a.broadcast_address)
         except AttributeError:


### PR DESCRIPTION
ipaddress.py:1106: SyntaxWarning: 'str' object is not callable; perhaps you missed a comma?