### PR TITLE
Fix typo in exception formatting of _is_subnet_of

### DIFF
--- a/ipaddress.py
+++ b/ipaddress.py
@@ -1103,7 +1103,7 @@ class _BaseNetwork(_IPAddressBase):
         try:
             # Always false if one is v4 and the other is v6.
             if a._version != b._version:
-                raise TypeError("%s and %s are not of the same version" (a, b))
+                raise TypeError("%s and %s are not of the same version" % (a, b))
             return (b.network_address <= a.network_address and
                     b.broadcast_address >= a.broadcast_address)
         except AttributeError:


### PR DESCRIPTION
It produces SyntaxWarning:

    SyntaxWarning: 'str' object is not callable; perhaps you missed a comma?
      raise TypeError("%s and %s are not of the same version" (a, b))

and upstream uses f-string: https://github.com/python/cpython/blob/e042a4553efd0ceca2234f68a4f1878f2ca04973/Lib/ipaddress.py#L991